### PR TITLE
Discover new module content

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ with "tfstate". Some examples:
     tfstate::aws_acm_certificate::my-alb::arn_suffix: some-dns-name
     tfstate::module::my_instance::aws_instance::ec2_instance::0::ami: some_ami_id
     tfstate::module::my_instance::aws_instance::ec2_instance::0::arn: some-arn
-    tfstate::module::my_instance::aws_instance::ec2_instance::0::associate_public_ip_address: false
+    tfstate::module::my_instance::my-awesome-instance::fqdn::aws_instance::ec2_instance::0::associate_public_ip_address: false
+
+**NOTE**
+Some Terraform modules might come with the format Hiera does not support.
+The special characters are removed during conversion.
+Example:
+    `module.instance["some-host.domain.com"].aws_instance.ec2_instance[0].private_ip`
+in Hiera:
+    `tfstate::module::instance::some-host::domain::com::aws_instance::ec2_instance::0::private_ip`
 
 If and only if all resources/data sources are stored inside a module you can
 use *no_root_module: true* in the options hash to remove the root module away
@@ -72,7 +80,8 @@ Example for hiera.yaml:
       data_hash: hiera_tfstate
       options:
         backend: 's3'
-        profile: 'hiera'
+        region: 'us-central-1'
+        profile: 'hiera' # optional
         bucket: 'terraform-state.example.org'
         key: 'foobar'
 

--- a/lib/puppet/functions/hiera_tfstate.rb
+++ b/lib/puppet/functions/hiera_tfstate.rb
@@ -31,7 +31,7 @@ Puppet::Functions.create_function(:hiera_tfstate) do
   end
 
   def validate_options(options)
-    valid_options = ['backend', 'debug', 'no_root_module', 'region', 'bucket', 'key', 'credentials_file', 'statefile']
+    valid_options = ['backend', 'debug', 'no_root_module', 'region', 'bucket', 'key', 'credentials_file', 'profile', 'statefile']
 
     options.each do |key, _value|
       unless valid_options.include?(key)
@@ -57,11 +57,11 @@ Puppet::Functions.create_function(:hiera_tfstate) do
   end
 
   def validate_s3_options(options)
-    required_options = ['region', 'bucket', 'key', 'credentials_file']
+    required_options = ['region', 'bucket', 'key']
 
     required_options.each do |key|
       unless options.include?(key)
-        raise(Puppet::DataBinding::LookupError, "[hiera_tfstate] required option #{key} missing!")
+        raise "[hiera_tfstate] required option #{key} missing!"
       end
     end
   end
@@ -75,25 +75,43 @@ Puppet::Functions.create_function(:hiera_tfstate) do
     begin
       state_content = File.read(options['statefile'])
     rescue Errno::ENOENT
-      raise Puppet::DataBinding::LookupError "ERROR: terraform state file #{options['statefile']} not found!"
+      raise "ERROR: terraform state file #{options['statefile']} not found!"
     end
     state_content
   end
 
   def download_from_s3(options)
     require 'aws-sdk-s3'
-    creds = YAML.safe_load(File.read(options['credentials_file']))
 
-    s3_client = Aws::S3::Client.new(region: options['region'],
-                                    access_key_id: creds['access_key_id'],
-                                    secret_access_key: creds['secret_access_key'])
+    aws_config = {region: options['region']}
 
-    resp = s3_client.get_object(bucket: options['bucket'], key: options['key'])
+    if options['credentials_file'].nil?
+      aws_config[:profile] = options['profile'] unless options['profile'].nil?
+    else
+      begin
+        creds = YAML.safe_load(File.read(options['credentials_file']))
+
+        aws_config[:access_key_id] = creds['access_key_id']
+        aws_config[:secret_access_key] = creds['secret_access_key']
+      rescue Errno::ENOENT
+        raise "ERROR: Can not read AWS credentials file in YAML format!"
+      rescue TypeError => e
+        raise "ERROR: Can not parse AWS credentials from file: #{e}"
+      end
+    end
+
+    begin
+      s3_client = Aws::S3::Client.new(aws_config)
+
+      resp = s3_client.get_object(bucket: options['bucket'], key: options['key'])
+    rescue Errno::ENOENT => e
+      raise "ERROR: Can not read from AWS S3!: #{e}"
+    end
     resp.body.read
   end
 
   def validate_terraform_version(raw_state)
-    return if raw_state['terraform_version'] =~ %r{0\.13\.\d+}
+    return if raw_state['terraform_version'] >= "0.13"
 
     raise 'ERROR: this Hiera backend supports only Terraform 0.13.x state files.'
   end
@@ -128,11 +146,12 @@ Puppet::Functions.create_function(:hiera_tfstate) do
       # - nil (resource defined in the root module)
       # - module.somemodule
       # - module.somemodule.module.nestedmodule
+      # - module.somemodule[\"somekey\"]
       #
       mod = if resource['module'].nil?
               ''
             else
-              resource['module']
+              resource['module'].gsub(/\[/,".").gsub(/[^-\.\w]/, "")
             end
 
       module_path = get_module_path(mod, options)


### PR DESCRIPTION
- Update Terraform version to handle versions above `0.13`
- Handle specific module structure `module.instance["some-host.domain.com"].aws_instance.ec2_instance[0]`
- Update the error handling to be compatible with bolt and the clear messages if configuration is not loaded
- Configuration update to have the clear splitting between AWS credentials and Puppet structure